### PR TITLE
Fixed a crash when printing without options and removed unused code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,16 +10,14 @@ var print = module.exports = function (data, options) {
 };
 
 function printObject (data, options) {
+  options = options || {};
+
   var defaults = {
     leftPadding: 2,
     rightPadding: 2
   };
   
   _.defaults(options, defaults);
-  
-  if (options) {
-    var padding = options.padding || 0;
-  }
   
   var keys = _.keys(data);
   var maxKeyLen = _.max(_.map(keys, function (key) {


### PR DESCRIPTION
If options aren't specified, `_.defaults` doesn't have an object to extend, so we need to assign `options` a default value. Also, it seems that the local `padding` variable wasn't actually being used.
