### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "as-array": "^2.0.0",
     "chalk": "~0.3.0",
     "feedback": "~0.3.x",
-    "lodash": "~2.2.1"
+    "lodash": "~4.17.10"
   },
   "devDependencies": {
     "tape": "~2.1.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "as-array": "^2.0.0",
-    "chalk": "~0.3.0",
+    "chalk": "~2.4.1",
     "feedback": "~0.3.x",
     "lodash": "~4.17.10"
   },


### PR DESCRIPTION
I noticed that npm flagged a [security vulnerability via the lodash dependency](https://nodesecurity.io/check/pretty-print). This updates lodash to the latest version, and also updates chalk while I'm at it. The tests pass with the new versions present.